### PR TITLE
DI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+!.gitignore
+composer.lock
+.idea/
+.idea/*
+/build
+/vendor
+vendor/*

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,14 +20,18 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('fpn_tag');
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('fpn_tag');
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('fpn_tag');
+        }
 
         $rootNode
             ->children()
                 ->arrayNode('model')
                     ->isRequired()
-                    ->cannotBeEmpty()
                     ->children()
                         ->scalarNode('tag_class')->isRequired()->cannotBeEmpty()->end()
                         ->scalarNode('tagging_class')->isRequired()->cannotBeEmpty()->end()


### PR DESCRIPTION
* Remove the TreeBuilder constructor deprecation for SF > 4.3 but keep it backward compatible.
* Remove the use of cannotBeEmpty because is not applicable on concrete node.
* Adds a simple .gitignore file